### PR TITLE
don't use path.join

### DIFF
--- a/lib/construct/prisma-function.ts
+++ b/lib/construct/prisma-function.ts
@@ -32,7 +32,7 @@ export class PrismaFunction extends lambdanode.NodejsFunction {
           beforeInstall: (i, o) => [
             // Copy prisma directory to Lambda code asset
             // the directory must be located at the same directory as your Lambda code
-            `cp -r ${path.join(i, "prisma")} ${o}`,
+            `cp -r ${i}/prisma ${o}`,
           ],
           beforeBundling: (i, o) => [],
           afterBundling: (i, o) => [],


### PR DESCRIPTION
If we used path.join, we'd get a Windows-formatted path when run on Windows platform. The path is intended for Linux docker environment so we must not use path.join for this purpose.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
