### PR TITLE
Escape special characters in password for Prisma connection URL

### DIFF
--- a/lib/stack/prisma-lambda-cdk-stack.ts
+++ b/lib/stack/prisma-lambda-cdk-stack.ts
@@ -25,7 +25,7 @@ export class PrismaLambdaCdkStack extends cdk.Stack {
         // You should create a database user with minimal privileges for your application.
         // Also refer to: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.MasterAccounts.html
         username: database.secret.secretValueFromJson("username").toString(),
-        password: database.secret.secretValueFromJson("password").toString(),
+        password: encodeURIComponent(database.secret.secretValueFromJson("password").toString()),
       },
     });
 

--- a/lib/stack/prisma-lambda-cdk-stack.ts
+++ b/lib/stack/prisma-lambda-cdk-stack.ts
@@ -25,6 +25,8 @@ export class PrismaLambdaCdkStack extends cdk.Stack {
         // You should create a database user with minimal privileges for your application.
         // Also refer to: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.MasterAccounts.html
         username: database.secret.secretValueFromJson("username").toString(),
+        // Prisma expects connection URL values to be URL-encoded (common in password strings)
+        // Also refer to: https://www.prisma.io/docs/orm/reference/connection-urls#special-characters
         password: encodeURIComponent(database.secret.secretValueFromJson("password").toString()),
       },
     });


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Just ran into this issue and it took several hours to debug.

Prisma requires any special characters in the connection string to be %-encoded (https://www.prisma.io/docs/orm/reference/connection-urls#special-characters)

If you happen to provision a DB with special characters in the password (reasonably likely if you let RDS pick the values) it will fail to connect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
