### PR TITLE
Upgrade AWS CDK packages and add cognito feature flag

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -17,5 +17,6 @@
     ]
   },
   "context": {
+    "@aws-cdk/cognito:logUserPoolClientSecretValue": false
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@aws-samples/prisma-lambda-cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk": "^2.1005.0",
-        "aws-cdk-lib": "^2.185.0",
+        "aws-cdk": "^2.1007.0",
+        "aws-cdk-lib": "^2.187.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.16"
       },
@@ -52,9 +52,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "40.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
-      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1290,9 +1290,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1005.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1005.0.tgz",
-      "integrity": "sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==",
+      "version": "2.1007.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1007.0.tgz",
+      "integrity": "sha512-/UOYOTGWUm+pP9qxg03tID5tL6euC+pb+xo0RBue+xhnUWwj/Bbsw6DbqbpOPMrNzTUxmM723/uMEQmM6S26dw==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
@@ -1305,9 +1305,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.185.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.185.0.tgz",
-      "integrity": "sha512-RNcQeNnInumDF1hq3gAf+/A6jhvYDof5a7418gEs/y6359gTYZpTCQkgItC50iV3MmkgerrBAdOE7CDEtQNDWw==",
+      "version": "2.187.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.187.0.tgz",
+      "integrity": "sha512-OrAWin+LD5sZhRF5cWuEYEkmC/sxxlgcAasCpfzeRsj6yDImwmeQsaKhM7xqzZQBInog6ZbN6oFZYiWEGJMSIA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1323,9 +1323,9 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.227",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^40.7.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
-    "aws-cdk": "^2.1005.0",
-    "aws-cdk-lib": "^2.185.0",
+    "aws-cdk": "^2.1007.0",
+    "aws-cdk-lib": "^2.187.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
This PR includes the following changes:

1. Upgrade aws-cdk from ^2.1005.0 to ^2.1007.0
2. Upgrade aws-cdk-lib from ^2.185.0 to ^2.187.0
3. Add feature flag `@aws-cdk/cognito:logUserPoolClientSecretValue: false` to cdk.json

The build process has been tested and works with these new versions.